### PR TITLE
Added "not installed games" feature for Game Jolt

### DIFF
--- a/libraries.md
+++ b/libraries.md
@@ -55,4 +55,4 @@
 [^g]: Imports all supported games on import regardless of actual ownership status
 [^h]: Play time is always tracked when launched through Playnite
 [^i]: Not strictly speaking installed, but playable via streaming
-[^j]: Only games that were purchased as there is now ownership for free games
+[^j]: Only games that were purchased, as there is no ownership for free games

--- a/libraries.md
+++ b/libraries.md
@@ -9,7 +9,7 @@
 | EA                 | •               | •[^e]               | •                 | •                    | •            |
 | Epic               | •               | •                   | •                 | •                    | •            |
 | Fanatical          |                 | •                   |                   |                      |              |
-| Game Jolt          | •               |                     | •                 |                      |              |
+| Game Jolt          | •               | •[^j]               | •                 |                      |              |
 | GamersGate         | •               | •[^d]               |                   |                      | •[^c]        |
 | GOG                | •               | •                   | •                 | •                    | •            |
 | Groupees           | •               | •[^d]               |                   |                      | •[^c]        |
@@ -55,3 +55,4 @@
 [^g]: Imports all supported games on import regardless of actual ownership status
 [^h]: Play time is always tracked when launched through Playnite
 [^i]: Not strictly speaking installed, but playable via streaming
+[^j]: Only games that were purchased as there is now ownership for free games


### PR DESCRIPTION
Game Jolt library supports "not installed games" when a user name is provided in the settings.
It only supports games purchased with money as there is no ownership for free games in Game Jolt